### PR TITLE
500 status code & rewrite instead of redirect.

### DIFF
--- a/Sitecore.MultisiteHttpModule/Errors/ErrorHandler.cs
+++ b/Sitecore.MultisiteHttpModule/Errors/ErrorHandler.cs
@@ -47,10 +47,12 @@ namespace Sitecore.MultisiteHttpModule.Errors
             var targetErrorPage = !String.IsNullOrEmpty(errorPagePath) ? errorPagePath : _settings.DefaultErrorPage;
 
             HttpContext.Current.Server.ClearError();
-            HttpContext.Current.Response.Redirect(String.Format("http://{0}{1}?aspxerrorpath={2}",
-                Context.Site.TargetHostName,
-                targetErrorPage,
-                HttpContext.Current.Server.UrlEncode(HttpContext.Current.Request.Url.LocalPath)), true);
+            HttpContext.Current.Response.StatusCode = 500;
+            HttpContext.Current.Server.Transfer(targetErrorPage);
+            //HttpContext.Current.Response.Redirect(String.Format("http://{0}{1}?aspxerrorpath={2}",
+            //    Context.Site.TargetHostName,
+            //    targetErrorPage,
+            //    HttpContext.Current.Server.UrlEncode(HttpContext.Current.Request.Url.LocalPath)), true);
         }
 
     }

--- a/Sitecore.MultisiteHttpModule/Errors/ErrorHandler.cs
+++ b/Sitecore.MultisiteHttpModule/Errors/ErrorHandler.cs
@@ -49,10 +49,6 @@ namespace Sitecore.MultisiteHttpModule.Errors
             HttpContext.Current.Server.ClearError();
             HttpContext.Current.Response.StatusCode = 500;
             HttpContext.Current.Server.Transfer(targetErrorPage);
-            //HttpContext.Current.Response.Redirect(String.Format("http://{0}{1}?aspxerrorpath={2}",
-            //    Context.Site.TargetHostName,
-            //    targetErrorPage,
-            //    HttpContext.Current.Server.UrlEncode(HttpContext.Current.Request.Url.LocalPath)), true);
         }
 
     }


### PR DESCRIPTION
Hi, I noticed that the 500 error pages didn't use a status code of 500.

And personally I prefer 500 rewrites instead of redirects to /errors/my-site-500-error.html (this one is just personal preference.)  Perhaps a future improvement is to allow user to specify.